### PR TITLE
Version 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@ note: from this ver you must have at least `redux-saga-routines 3.2.0` installed
 
 ### Version 3.1.2
 - fix typo in readme
+- rename socket stages to 'CONNECTED', 'DISCONNECTED', 'JOIN_CHANNEL', 'CHANNEL_JOINED', 'LEAVE_CHANNEL', 'CHANNEL_LEAVED'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,6 @@ note: from this ver you must have at least `redux-saga-routines 3.2.0` installed
 ### Version 3.1.1
 - change default stages for `creteSocketRoutine`:
   - rename 'MESSAGE_SENDED' and 'MESSAGE_RECEIVED' to 'SENDED' and 'RECEIVED'
+
+### Version 3.1.2
+- fix typo in readme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ note: from this ver you must have at least `redux-saga-routines 3.2.0` installed
 ### Version 3.1.2
 - fix typo in readme
 - rename socket stages to 'CONNECTED', 'DISCONNECTED', 'JOIN_CHANNEL', 'CHANNEL_JOINED', 'LEAVE_CHANNEL', 'CHANNEL_LEAVED'
+- createCustomRoutine: allow to pass one stage as a string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ note: from this ver you must have at least `redux-saga-routines 3.2.0` installed
 - change default stages for `creteSocketRoutine`:
   - rename 'MESSAGE_SENDED' and 'MESSAGE_RECEIVED' to 'SENDED' and 'RECEIVED'
 
-### Version 3.1.2
-- fix typo in readme
-- rename socket stages to 'CONNECTED', 'DISCONNECTED', 'JOIN_CHANNEL', 'CHANNEL_JOINED', 'LEAVE_CHANNEL', 'CHANNEL_LEAVED'
-- createCustomRoutine: allow to pass one stage as a string
+### Version 3.2.0
+- Change `creteSocketRoutine` default stages to 'CONNECTED', 'DISCONNECTED', 'JOIN_CHANNEL', 'CHANNEL_JOINED', 'LEAVE_CHANNEL', 'CHANNEL_LEAVED' and export defaultSocketStages
+- Ability to create a bunch of routines with new method `createRoutines`
+- Allow to pass one stage as a string for `createCustomRoutine`
+- Fix typo in readme

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ note: from `ver 3` it uses updated `redux-saga-routines` API, so you must have a
   - `createSocketRoutine(typePrefix, stages, payloadCreator, metaCreator)`
   - default stages are: 'CONNECTED', 'DISCONNECTED', 'SENDED', 'RECEIVED'
   - you can extend them as well by `stages` argument
+- [create a bunch of routines](#create-routines)
+  - `createRoutines(scheme)`
+  - scheme is a special object, check exmaple
 
 ### Extend any routine:
 ```js
@@ -178,7 +181,7 @@ import { createSocketRoutine } from 'extend-saga-routines';
 const chat = createSocketRoutine('chat', ['WHY', 'NOT']);
 
 console.log(projects._STAGES);
-// ["CONNECTED", "DISCONNECTED", "SENDED", "RECEIVED"];
+// ['CONNECTED', 'DISCONNECTED', 'JOIN_CHANNEL', 'CHANNEL_JOINED', 'LEAVE_CHANNEL', 'CHANNEL_LEAVED']
 console.log(chat.WHY);
 // 'chat/WHY';
 console.log(chat.why(42));
@@ -187,4 +190,158 @@ console.log(chat.NOT);
 // 'chat/NOT';
 console.log(chat.not(42));
 // { type: "chat/NOT", payload: 42 }
+```
+
+### Create routines
+Now you can create a bunch of routines at ones by using `createRoutines`.
+
+#### Examples:
+
+##### Default routines with `createRoutines`:
+```js
+import { createRoutines } from 'extend-saga-routines';
+
+const routines = createRoutines({
+  firstRoutine: null,
+  secondRoutine: null,
+  thirdRoutine: null
+});
+
+console.log(routines.firstRoutine._STAGES);
+// ["TRIGGER", "REQUEST", "SUCCESS", "FAILURE", "FULFILL"]
+
+console.log(routines.firstRoutine(42));
+// { type: "firstRoutine/TRIGGER", payload: 42 }
+
+console.log(routines.secondRoutine(42));
+// { type: "secondRoutine/TRIGGER", payload: 42 }
+console.log(routines.secondRoutine.request(42));
+// { type: "secondRoutine/REQUEST", payload: 42 }
+
+// also you can use destructuring assignment
+const { firstRoutine, secondRoutine, thirdRoutine } = routines;
+
+```
+
+##### Extended routines with `createRoutines`:
+```
+To create extended routine inside of bunch
+you need to start with `_` underscore
+each additional stage. 
+Next stage name will be transformed 
+to without underscore. 
+(`_OPEN` => routine.OPEN, type: 'parent/OPEN' ,routine.open() )
+```
+```js
+import { createRoutines } from 'extend-saga-routines';
+
+const routines = createRoutines({
+  firstRoutine: {
+    _OPEN: null,
+    _CLOSE: null
+  },
+  secondRoutine: null,
+  thirdRoutine: null
+});
+
+console.log(routines.firstRoutine._STAGES);
+// ["TRIGGER", "REQUEST", "SUCCESS", "FAILURE", "FULFILL", "TOGGLE_INFO", "OPEN", "CLOSE"]
+
+console.log(routines.firstRoutine(42));
+// { type: "firstRoutine/TRIGGER", payload: 42 }
+
+console.log(routines.firstRoutine.open(84));
+// { type: "firstRoutine/OPEN", payload: 84 }
+
+console.log(routines.secondRoutine._STAGES);
+// ["TRIGGER", "REQUEST", "SUCCESS", "FAILURE", "FULFILL"]
+
+```
+
+##### Create `custom` or `socket` routine with `createRoutines`:
+```js
+import { createRoutines } from 'extend-saga-routines';
+
+const routines = createRoutines({
+  firstRoutine: [
+    { method: 'custom' },
+    {
+      _OPEN: null,
+      _CLOSE: null
+    }
+  ],
+  secondRoutine: null,
+  socket: [
+    { method: 'socket' },
+    {
+      _ADD: null
+    }
+  ]
+});
+
+console.log(routines.firstRoutine(42))
+// { type: "firstRoutine/OPEN", payload: 42 }
+
+console.log(routines.firstRoutine._STAGES);
+// ['OPEN', 'CLOSE']
+
+console.log(routines.secondRoutine._STAGES);
+// ['CONNECTED', 'DISCONNECTED', 'JOIN_CHANNEL', 'CHANNEL_JOINED', 'LEAVE_CHANNEL', 'CHANNEL_LEAVED'. 'ADD']
+
+```
+
+##### Change payload and meta creators with `createRoutines`:
+
+pretty similar with redux-action [createActions method](https://redux-actions.js.org/api/createaction#createactions)
+
+```js
+import { createRoutines } from 'extend-saga-routines';
+
+const routines = createRoutines({
+  multiplyPayloads: {
+    _TRIGGER: [ (payload) => payload * 2 ],
+    _REQUEST: [ (payload) => payload * 3 ],
+  },
+  customMeta: {
+    _TRIGGER: [ null, () => ({ some: 'data' }) ],
+  },
+  payloadAndMeta: {
+    _TRIGGER: [
+      (payload) => payload / 2, 
+      () => ({ info: 'divide' })
+    ]
+  },
+  extendedRoutine: {
+    _PLUS_TEN: [
+      (payload) => payload + 10
+    ]
+  },
+  customRoutine: [
+    { method: 'custom' },
+    {
+      _OPEN: null,
+      _CLOSE: null
+    }
+  ],
+});
+
+console.log(routines.multiplyPayloads(2))
+// { type: "multiplyPayloads/TRIGGER", payload: 4 }
+
+console.log(routines.multiplyPayloads.request(2))
+// { type: "multiplyPayloads/TRIGGER", payload: 6 
+
+console.log(routines.customMeta(2))
+// { type: "customMeta/TRIGGER", payload: 2, meta: { info: "divide" } }
+
+console.log(routines.payloadAndMeta(4))
+// { type: "payloadAndMeta/TRIGGER", payload: 2, meta: { info: "divide" } }
+
+console.log(routines.extendedRoutine(42))
+// { type: "extendedRoutine/PLUS_TEN", payload: 420 }
+
+console.log(routines.extendedRoutine.plusTen(42))
+// { type: "extendedRoutine/PLUS_TEN", payload: 420 }
+
+console.log(routines.customRoutine)
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Extend any routine with custom stages, create routine with more than defafult stages and create custom routine.
+## Extend any routine with custom stages, create routine with more than default stages and create custom routine.
 
 ![npm](https://img.shields.io/npm/v/extend-saga-routines.svg)
 ![npm](https://img.shields.io/npm/dm/extend-saga-routines.svg)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extend-saga-routines",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Extend any routine with custom stages, create routine that has redux-saga-routines default stages and create routine with only yours custom stages.",
   "main": "build/index.js",
   "scripts": {
@@ -13,6 +13,8 @@
     "redux",
     "saga",
     "redux-saga",
+    "redux-actions",
+    "actionCreator",
     "routines",
     "redux-saga-routines",
     "extend-saga-routines",

--- a/src/createCustomRoutine.js
+++ b/src/createCustomRoutine.js
@@ -4,9 +4,11 @@ export default function createCustomRoutine(typePrefix, stages, payloadCreator, 
   if(typeof typePrefix !== 'string'){
     throw new Error('`typePrefix` must be a string');
   };
-  if(!Array.isArray(stages)){
-    throw new Error('createCustomRoutine `stages` must be an array');
+  if(!stages || stages.length === 0){
+    throw new Error('`stages` must not be empty');
   };
 
-  return createRoutineCreator(stages)(typePrefix, payloadCreator, metaCreator);
+  const stagesArray = [].concat(stages);
+
+  return createRoutineCreator(stagesArray)(typePrefix, payloadCreator, metaCreator);
 };

--- a/src/createRoutines.js
+++ b/src/createRoutines.js
@@ -12,7 +12,6 @@ export default function createRoutines(scheme){
       if(nameSpace.startsWith('_')) {
         continue;
       }
-      let allStages = [];
       let payloadAndMeta = [];
       let customStages = [];
       let method = '';
@@ -36,19 +35,16 @@ export default function createRoutines(scheme){
           payloadAndMeta
         );
       } 
-      // else if(!nameSpace.startsWith('_')){
-        
-      // }
 
-      switch(method) {
-        case 'custom':
-          allStages = customStages;
-          break;
-        default:
-          allStages = [...defaultRoutineStages, ...customStages].filter((value, index, arr) => arr.indexOf(value) === index)
-      }
+      const getStages = (method) => {
+        const methods = {
+          'custom': customStages,
+          'default': [...defaultRoutineStages, ...customStages].filter((value, index, arr) => arr.indexOf(value) === index)
+        }
+        return methods[method] || methods['default'];
+      };
 
-      result[nameSpace] = createRoutineCreator(allStages).apply(null, [nameSpace, ...payloadAndMeta]);
+      result[nameSpace] = createRoutineCreator(getStages(method)).apply(null, [nameSpace, ...payloadAndMeta]);
 
       if (typeof inside === "object" && inside != null){
         iterate(inside);

--- a/src/createRoutines.js
+++ b/src/createRoutines.js
@@ -35,16 +35,17 @@ export default function createRoutines(scheme){
           ],
           payloadAndMeta
         );
-      } else if(!nameSpace.startsWith('_')){
+      } 
+      // else if(!nameSpace.startsWith('_')){
         
-      }
+      // }
 
       switch(method) {
         case 'custom':
           allStages = customStages;
           break;
         default:
-          allStages = [...defaultRoutineStages, ...customStages]
+          allStages = [...defaultRoutineStages, ...customStages].filter((value, index, arr) => arr.indexOf(value) === index)
       }
 
       result[nameSpace] = createRoutineCreator(allStages).apply(null, [nameSpace, ...payloadAndMeta]);

--- a/src/createRoutines.js
+++ b/src/createRoutines.js
@@ -35,7 +35,9 @@ export default function createRoutines(scheme){
           ],
           payloadAndMeta
         );
-      };
+      } else if(!nameSpace.startsWith('_')){
+        
+      }
 
       switch(method) {
         case 'custom':
@@ -54,5 +56,5 @@ export default function createRoutines(scheme){
   }
 
   iterate(scheme);
-  return scheme;
+  return result;
 };

--- a/src/createRoutines.js
+++ b/src/createRoutines.js
@@ -1,0 +1,55 @@
+import { createRoutineCreator, defaultRoutineStages } from 'redux-saga-routines';
+
+export default function createRoutines(scheme){
+  if(typeof scheme !== 'object' || Array.isArray(scheme)){
+    throw new Error('`typePrefix` must be an object');
+  };
+
+  let result = {};
+
+  function iterate(obj){
+    for(let [prefix, inside] of Object.entries(obj)) {
+      if(prefix.startsWith('_')) {
+        continue;
+      }
+      
+      let payloadAndMeta = {payload: () => {}, meta: () => {}};
+      if(inside != null){
+        payloadAndMeta = Object.keys(inside).reduce((acc, cur) => 
+          cur.startsWith('_') ? 
+            { ...acc,
+              payload: { ...acc.payload, [cur.substring(1).toLowerCase()]: inside[cur].payload },
+              meta: { ...acc.meta, [cur.substring(1).toLowerCase()]: inside[cur].meta }
+            } 
+            :
+            acc,
+          payloadAndMeta
+        );
+      }
+
+      result[prefix] = createRoutineCreator(defaultRoutineStages)(prefix, {...payloadAndMeta});
+
+      if (typeof inside == "object" && inside != null){
+        iterate(inside);
+      } 
+    }
+  }
+
+  iterate({
+    people: {
+      search: {
+        _TRIGGER: {
+          payload: ({ phone }) => parseInt(phone, 2),
+          meta: () => ({ trigger: true })
+        },
+        otherNameSpace: null
+       },
+      add: null,
+      remove: null
+    }
+  });
+
+  console.log(result.search.trigger({ phone: 101010 }));
+  ///console.log(result);
+
+};

--- a/src/createRoutines.js
+++ b/src/createRoutines.js
@@ -2,54 +2,57 @@ import { createRoutineCreator, defaultRoutineStages } from 'redux-saga-routines'
 
 export default function createRoutines(scheme){
   if(typeof scheme !== 'object' || Array.isArray(scheme)){
-    throw new Error('`typePrefix` must be an object');
+    throw new Error('`scheme` must be an object');
   };
 
   let result = {};
 
   function iterate(obj){
-    for(let [prefix, inside] of Object.entries(obj)) {
-      if(prefix.startsWith('_')) {
+    for(let [nameSpace, value] of Object.entries(obj)) {
+      if(nameSpace.startsWith('_')) {
         continue;
       }
-      
-      let payloadAndMeta = {payload: () => {}, meta: () => {}};
-      if(inside != null){
-        payloadAndMeta = Object.keys(inside).reduce((acc, cur) => 
-          cur.startsWith('_') ? 
-            { ...acc,
-              payload: { ...acc.payload, [cur.substring(1).toLowerCase()]: inside[cur].payload },
-              meta: { ...acc.meta, [cur.substring(1).toLowerCase()]: inside[cur].meta }
-            } 
-            :
-            acc,
-          payloadAndMeta
-        );
+      let allStages = [];
+      let payloadAndMeta = [];
+      let customStages = [];
+      let method = '';
+      let inside = null;
+
+      if(Array.isArray(value)){
+        method = value[0].method;
+        inside = value[1];
+      } else {
+        inside = value;
       }
 
-      result[prefix] = createRoutineCreator(defaultRoutineStages)(prefix, {...payloadAndMeta});
+      if(inside != null){
+        let insideStages = Object.keys(inside).filter(i => i.startsWith('_'))
+        customStages = insideStages.reduce((acc, cur) => !defaultRoutineStages.includes(cur) ? [...acc, cur.substring(1)] : acc ,[]);
+        payloadAndMeta = insideStages.reduce((acc, cur) => 
+          [
+            { ...acc[0], [cur.substring(1).toLowerCase()]: inside[cur] !== null ? inside[cur][0] : null },
+            { ...acc[1], [cur.substring(1).toLowerCase()]: inside[cur] !== null ? inside[cur][1] : null }
+          ],
+          payloadAndMeta
+        );
+      };
 
-      if (typeof inside == "object" && inside != null){
+      switch(method) {
+        case 'custom':
+          allStages = customStages;
+          break;
+        default:
+          allStages = [...defaultRoutineStages, ...customStages]
+      }
+
+      result[nameSpace] = createRoutineCreator(allStages).apply(null, [nameSpace, ...payloadAndMeta]);
+
+      if (typeof inside === "object" && inside != null){
         iterate(inside);
-      } 
+      }
     }
   }
 
-  iterate({
-    people: {
-      search: {
-        _TRIGGER: {
-          payload: ({ phone }) => parseInt(phone, 2),
-          meta: () => ({ trigger: true })
-        },
-        otherNameSpace: null
-       },
-      add: null,
-      remove: null
-    }
-  });
-
-  console.log(result.search.trigger({ phone: 101010 }));
-  ///console.log(result);
-
+  iterate(scheme);
+  return scheme;
 };

--- a/src/createRoutines.js
+++ b/src/createRoutines.js
@@ -1,4 +1,5 @@
 import { createRoutineCreator, defaultRoutineStages } from 'redux-saga-routines';
+import { defaultSocketStages } from './createSocketRoutine';
 
 export default function createRoutines(scheme){
   if(typeof scheme !== 'object' || Array.isArray(scheme)){
@@ -36,9 +37,11 @@ export default function createRoutines(scheme){
         );
       } 
 
+      // todo: use API methods instead of create stages to each method
       const getStages = (method) => {
         const methods = {
           'custom': customStages,
+          'socket': [...defaultSocketStages, ...customStages],
           'default': [...defaultRoutineStages, ...customStages].filter((value, index, arr) => arr.indexOf(value) === index)
         }
         return methods[method] || methods['default'];

--- a/src/createSocketRoutine.js
+++ b/src/createSocketRoutine.js
@@ -1,6 +1,6 @@
 import { createRoutineCreator } from 'redux-saga-routines';
 
-const defaultSocketStages = ['CONNECTED', 'DISCONNECTED', 'JOIN_CHANNEL', 'CHANNEL_JOINED', 'LEAVE_CHANNEL', 'CHANNEL_LEAVED'];
+export const defaultSocketStages = ['CONNECTED', 'DISCONNECTED', 'JOIN_CHANNEL', 'CHANNEL_JOINED', 'LEAVE_CHANNEL', 'CHANNEL_LEAVED'];
 
 export default function createSocketRoutine(typePrefix, stages, payloadCreator, metaCreator){
   if(typeof typePrefix !== 'string'){

--- a/src/createSocketRoutine.js
+++ b/src/createSocketRoutine.js
@@ -1,11 +1,14 @@
 import { createRoutineCreator } from 'redux-saga-routines';
 
-export default function createSocketRoutine(typePrefix, stages = [], payloadCreator, metaCreator){
+const defaultSocketStages = ['CONNECTED', 'DISCONNECTED', 'JOIN_CHANNEL', 'CHANNEL_JOINED', 'LEAVE_CHANNEL', 'CHANNEL_LEAVED'];
+
+export default function createSocketRoutine(typePrefix, stages, payloadCreator, metaCreator){
   if(typeof typePrefix !== 'string'){
     throw new Error('`typePrefix` must be a string');
   };
-
-  const defaultSocketStages = ['CONNECTED', 'DISCONNECTED', 'SENDED', 'RECEIVED'];
+  if(!stages || stages.length === 0){
+    throw new Error('`stages` must not be empty');
+  };
 
   const allStages = defaultSocketStages.concat(stages);
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,3 +3,4 @@ export { default } from './extendRoutine';
 export { default as createExtendedRoutine } from './createExtendedRoutine';
 export { default as createCustomRoutine } from './createCustomRoutine';
 export { default as createSocketRoutine } from './createSocketRoutine';
+export { default as createRoutines } from './createRoutines';

--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,5 @@ export { default } from './extendRoutine';
 
 export { default as createExtendedRoutine } from './createExtendedRoutine';
 export { default as createCustomRoutine } from './createCustomRoutine';
-export { default as createSocketRoutine } from './createSocketRoutine';
+export { default as createSocketRoutine, defaultSocketStages } from './createSocketRoutine';
 export { default as createRoutines } from './createRoutines';

--- a/test/createCustomRoutine.js
+++ b/test/createCustomRoutine.js
@@ -31,11 +31,7 @@ describe('createCustomRoutine', () => {
   });
 
   it('should throw an error if stages is not defined', () => {
-    expect(() =>  createCustomRoutine(PREFIX)).to.throw('createCustomRoutine `stages` must be an array');
-  });
-
-  it('should throw an error if stages is a string', () => {
-    expect(() =>  createCustomRoutine(PREFIX, 'STAGE_1')).to.throw('createCustomRoutine `stages` must be an array');
+    expect(() =>  createCustomRoutine(PREFIX)).to.throw('`stages` must not be empty');
   });
 
   it('should create a custom routine', () => {
@@ -113,5 +109,15 @@ describe('createCustomRoutine', () => {
     expect(routine.someLongType.toString()).to.equal(SOME_LONG_TYPE);
     expect(routine.someLongType(payload)).to.deep.equal(someLongTypeAction);
 
+  });
+
+  it('should create extened routine if types arg is string', () => {
+
+    const routine = createCustomRoutine(PREFIX, 'SOME_LONG_TYPE');
+
+    expect(routine.someLongType).to.be.a('function');
+    expect(routine.SOME_LONG_TYPE).to.equal(SOME_LONG_TYPE);
+    expect(routine.someLongType.toString()).to.equal(SOME_LONG_TYPE);
+    expect(routine.someLongType(payload)).to.deep.equal(someAction);
   });
 });

--- a/test/createRoutines.js
+++ b/test/createRoutines.js
@@ -6,9 +6,30 @@ import { defaultRoutineStages } from 'redux-saga-routines';
 
 const SCHEME = {
   default: null,
+  multiplyPayloads: {
+    _TRIGGER: [(payload) => payload * 2],
+    _REQUEST: [(payload) => payload * 3],
+    _SUCCESS: [(payload) => payload * 4],
+    _FAILURE: [(payload) => payload * 5],
+    _FULFILL: [(payload) => payload * 6]
+  },
+  customMeta: {
+    _TRIGGER: [null, () => ({ some: 'data' })],
+    _REQUEST: [null, () => ({ some: 'data' })],
+    _SUCCESS: [null, () => ({ some: 'data' })],
+    _FAILURE: [null, () => ({ some: 'data' })],
+    _FULFILL: [null, () => ({ some: 'data' })]
+  },
   people: {
     search: {
       _ANY: null,
+      _CUSTOM_PAYLOAD: [
+        (payload) => payload * 2
+      ],
+      _CUSTOM_META: [
+        null,
+        () => ({ some: 'info' })
+      ],
       _TRIGGER: [
         ({ number }) => number * 2,
         () => ({ trigger: true })
@@ -40,7 +61,7 @@ describe('create a bunch of routines with `createRoutines`', () => {
 
   it('should create default routine', () => {
     const routine = createRoutines(SCHEME).default;
-
+    
     const PREFIX = 'default';
     const TRIGGER = `${PREFIX}/TRIGGER`;
     const REQUEST = `${PREFIX}/REQUEST`;
@@ -105,13 +126,181 @@ describe('create a bunch of routines with `createRoutines`', () => {
     expect(routine.fulfill(payload)).to.deep.equal(fulfillAction);
   });
 
-  // it('should be able to change payload to default stages', () => {
-  //   const routines = createRoutines(SCHEME);
-  //   const result = 
+  it('should change payload to default stages', () => {
+    const routine = createRoutines(SCHEME).multiplyPayloads;
     
-  //   expect(routines.trigger).to.be.a('function');
-  //   expect(routines.TRIGGER).to.equal(SOME_LONG_TYPE);
-  //   expect(routines.someLongType.toString()).to.equal(SOME_LONG_TYPE);
-  //   expect(routines.someLongType(payload)).to.deep.equal(someLongTypeAction);
-  // })
+    const PREFIX = 'multiplyPayloads';
+    const TRIGGER = `${PREFIX}/TRIGGER`;
+    const REQUEST = `${PREFIX}/REQUEST`;
+    const SUCCESS = `${PREFIX}/SUCCESS`;
+    const FAILURE = `${PREFIX}/FAILURE`;
+    const FULFILL = `${PREFIX}/FULFILL`;
+
+    const originalPayload = 42;
+
+    const triggerAction = {
+      type: TRIGGER,
+      payload: 84, // originalPayload * 2
+    };
+    const requestAction = {
+      type: REQUEST,
+      payload: 126, // originalPayload * 3,
+    };
+    const successAction = {
+      type: SUCCESS,
+      payload: 168, // originalPayload * 4,
+    };
+    const failureAction = {
+      type: FAILURE,
+      payload: 210, // originalPayload * 5,
+    };
+    const fulfillAction = {
+      type: FULFILL,
+      payload: 252, // originalPayload * 6,
+    };
+    
+    expect(routine).to.be.a('function');
+    expect(routine.toString()).to.equal(TRIGGER);
+    expect(routine(originalPayload)).to.deep.equal(triggerAction);
+
+    expect(routine.trigger).to.be.a('function');
+    expect(routine.TRIGGER).to.equal(TRIGGER);
+    expect(routine.trigger.toString()).to.equal(TRIGGER);
+    expect(routine.trigger(originalPayload)).to.deep.equal(triggerAction);
+
+    expect(routine.request).to.be.a('function');
+    expect(routine.REQUEST).to.equal(REQUEST);
+    expect(routine.request.toString()).to.equal(REQUEST);
+    expect(routine.request(originalPayload)).to.deep.equal(requestAction);
+
+    expect(routine.success).to.be.a('function');
+    expect(routine.SUCCESS).to.equal(SUCCESS);
+    expect(routine.success.toString()).to.equal(SUCCESS);
+    expect(routine.success(originalPayload)).to.deep.equal(successAction);
+
+    expect(routine.failure).to.be.a('function');
+    expect(routine.FAILURE).to.equal(FAILURE);
+    expect(routine.failure.toString()).to.equal(FAILURE);
+    expect(routine.failure(originalPayload)).to.deep.equal(failureAction);
+
+    expect(routine.fulfill).to.be.a('function');
+    expect(routine.FULFILL).to.equal(FULFILL);
+    expect(routine.fulfill.toString()).to.equal(FULFILL);
+    expect(routine.fulfill(originalPayload)).to.deep.equal(fulfillAction);
+    
+  });
+
+  it('should change meta to default stages', () => {
+    const routine = createRoutines(SCHEME).customMeta;
+    
+    const PREFIX = 'customMeta';
+    const TRIGGER = `${PREFIX}/TRIGGER`;
+    const REQUEST = `${PREFIX}/REQUEST`;
+    const SUCCESS = `${PREFIX}/SUCCESS`;
+    const FAILURE = `${PREFIX}/FAILURE`;
+    const FULFILL = `${PREFIX}/FULFILL`;
+
+    const meta = { some: 'data' };
+
+    const triggerAction = {
+      type: TRIGGER,
+      meta
+    };
+    const requestAction = {
+      type: REQUEST,
+      meta
+    };
+    const successAction = {
+      type: SUCCESS,
+      meta
+    };
+    const failureAction = {
+      type: FAILURE,
+      meta
+    };
+    const fulfillAction = {
+      type: FULFILL,
+      meta
+    };
+    
+    expect(routine).to.be.a('function');
+    expect(routine.toString()).to.equal(TRIGGER);
+    expect(routine()).to.deep.equal(triggerAction);
+
+    expect(routine.trigger).to.be.a('function');
+    expect(routine.TRIGGER).to.equal(TRIGGER);
+    expect(routine.trigger.toString()).to.equal(TRIGGER);
+    expect(routine.trigger()).to.deep.equal(triggerAction);
+
+    expect(routine.request).to.be.a('function');
+    expect(routine.REQUEST).to.equal(REQUEST);
+    expect(routine.request.toString()).to.equal(REQUEST);
+    expect(routine.request()).to.deep.equal(requestAction);
+
+    expect(routine.success).to.be.a('function');
+    expect(routine.SUCCESS).to.equal(SUCCESS);
+    expect(routine.success.toString()).to.equal(SUCCESS);
+    expect(routine.success()).to.deep.equal(successAction);
+
+    expect(routine.failure).to.be.a('function');
+    expect(routine.FAILURE).to.equal(FAILURE);
+    expect(routine.failure.toString()).to.equal(FAILURE);
+    expect(routine.failure()).to.deep.equal(failureAction);
+
+    expect(routine.fulfill).to.be.a('function');
+    expect(routine.FULFILL).to.equal(FULFILL);
+    expect(routine.fulfill.toString()).to.equal(FULFILL);
+    expect(routine.fulfill()).to.deep.equal(fulfillAction);
+    
+  });
+
+  it('should add custom stages to routine', () => {
+    const routine = createRoutines(SCHEME).search;
+
+    expect(routine._STAGES).to.deep.equal([...defaultRoutineStages, 'ANY', 'CUSTOM_PAYLOAD', 'CUSTOM_META']);
+    // expect(routine._PREFIX).to.equal(PREFIX);
+
+    const PREFIX = 'search';
+    const ANY = `${PREFIX}/ANY`;
+    const payload = { some: 'data' }
+    const anyAction = {
+      type: `${PREFIX}/ANY`,
+      payload
+    }
+
+    expect(routine.any).to.be.a('function');
+    expect(routine.ANY).to.equal(ANY);
+    expect(routine.any.toString()).to.equal(ANY);
+    expect(routine.any(payload)).to.deep.equal(anyAction);
+  });
+
+  it('should add payloadCreator to custom stage', () => {
+    const routine = createRoutines(SCHEME).search;
+
+    const PREFIX = 'search';
+    const payload = 42;
+    const customPayloadAction = {
+      type: `${PREFIX}/CUSTOM_PAYLOAD`,
+      payload: 84 // 42 * 2
+    }
+
+    expect(routine.customPayload(payload)).to.deep.equal(customPayloadAction);
+  });
+
+  it('should add metaCreator to custom stage', () => {
+    const routine = createRoutines(SCHEME).search;
+
+    const PREFIX = 'search';
+    const payload = 42;
+    const customMetaAction = {
+      type: `${PREFIX}/CUSTOM_META`,
+      payload,
+      meta: { 
+        some: 'info'
+      }
+    }
+
+    expect(routine.customMeta(payload)).to.deep.equal(customMetaAction);
+  });
+
 });

--- a/test/createRoutines.js
+++ b/test/createRoutines.js
@@ -1,0 +1,3 @@
+import { createRoutines } from '../src';
+
+createRoutines({});

--- a/test/createRoutines.js
+++ b/test/createRoutines.js
@@ -1,6 +1,11 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+
 import { createRoutines } from '../src';
+import { defaultRoutineStages } from 'redux-saga-routines';
 
 const SCHEME = {
+  default: null,
   people: {
     search: {
       _ANY: null,
@@ -12,7 +17,6 @@ const SCHEME = {
         null,
         () => ({ ignoreCache: true })
       ],
-      _OTHER_STAGE: null,
       otherNameSpace: null
     },
     customRoutine: [
@@ -28,8 +32,86 @@ const SCHEME = {
   }
 }
 
-createRoutines(SCHEME);
-
-const RESULT = {
+describe('create a bunch of routines with `createRoutines`', () => { 
   
-}
+  it('should throw an error scheme is undefined of not an object', () => {
+    expect(() => createRoutines()).to.throw('`scheme` must be an object');
+  });
+
+  it('should create default routine', () => {
+    const routine = createRoutines(SCHEME).default;
+
+    const PREFIX = 'default';
+    const TRIGGER = `${PREFIX}/TRIGGER`;
+    const REQUEST = `${PREFIX}/REQUEST`;
+    const SUCCESS = `${PREFIX}/SUCCESS`;
+    const FAILURE = `${PREFIX}/FAILURE`;
+    const FULFILL = `${PREFIX}/FULFILL`;
+
+    const payload = {
+      some: 'data',
+    };
+    const triggerAction = {
+      type: TRIGGER,
+      payload,
+    };
+    const requestAction = {
+      type: REQUEST,
+      payload,
+    };
+    const successAction = {
+      type: SUCCESS,
+      payload,
+    };
+    const failureAction = {
+      type: FAILURE,
+      payload,
+    };
+    const fulfillAction = {
+      type: FULFILL,
+      payload,
+    };
+
+    expect(routine).to.be.a('function');
+    expect(routine.toString()).to.equal(TRIGGER);
+    expect(routine(payload)).to.deep.equal(triggerAction);
+
+    expect(routine._STAGES).to.deep.equal(defaultRoutineStages);
+    expect(routine._PREFIX).to.equal(PREFIX);
+
+    expect(routine.trigger).to.be.a('function');
+    expect(routine.TRIGGER).to.equal(TRIGGER);
+    expect(routine.trigger.toString()).to.equal(TRIGGER);
+    expect(routine.trigger(payload)).to.deep.equal(triggerAction);
+
+    expect(routine.request).to.be.a('function');
+    expect(routine.REQUEST).to.equal(REQUEST);
+    expect(routine.request.toString()).to.equal(REQUEST);
+    expect(routine.request(payload)).to.deep.equal(requestAction);
+
+    expect(routine.success).to.be.a('function');
+    expect(routine.SUCCESS).to.equal(SUCCESS);
+    expect(routine.success.toString()).to.equal(SUCCESS);
+    expect(routine.success(payload)).to.deep.equal(successAction);
+
+    expect(routine.failure).to.be.a('function');
+    expect(routine.FAILURE).to.equal(FAILURE);
+    expect(routine.failure.toString()).to.equal(FAILURE);
+    expect(routine.failure(payload)).to.deep.equal(failureAction);
+
+    expect(routine.fulfill).to.be.a('function');
+    expect(routine.FULFILL).to.equal(FULFILL);
+    expect(routine.fulfill.toString()).to.equal(FULFILL);
+    expect(routine.fulfill(payload)).to.deep.equal(fulfillAction);
+  });
+
+  // it('should be able to change payload to default stages', () => {
+  //   const routines = createRoutines(SCHEME);
+  //   const result = 
+    
+  //   expect(routines.trigger).to.be.a('function');
+  //   expect(routines.TRIGGER).to.equal(SOME_LONG_TYPE);
+  //   expect(routines.someLongType.toString()).to.equal(SOME_LONG_TYPE);
+  //   expect(routines.someLongType(payload)).to.deep.equal(someLongTypeAction);
+  // })
+});

--- a/test/createRoutines.js
+++ b/test/createRoutines.js
@@ -1,3 +1,35 @@
 import { createRoutines } from '../src';
 
-createRoutines({});
+const SCHEME = {
+  people: {
+    search: {
+      _ANY: null,
+      _TRIGGER: [
+        ({ number }) => number * 2,
+        () => ({ trigger: true })
+      ],
+      _REQUEST: [
+        null,
+        () => ({ ignoreCache: true })
+      ],
+      _OTHER_STAGE: null,
+      otherNameSpace: null
+    },
+    customRoutine: [
+      { method: 'custom' },
+      {
+        _OPEN: [
+          ({ number }) => number * 2
+        ],
+        _CLOSE: null
+      }
+    ],
+    remove: null
+  }
+}
+
+createRoutines(SCHEME);
+
+const RESULT = {
+  
+}


### PR DESCRIPTION
createRoutines first version 
rename default socket stages 
pass one stage as a string 
fix typo 

### Version 3.2.0
- Ability to create a bunch of routines with new method `createRoutines` #15
- Change `creteSocketRoutine` default stages to 'CONNECTED', 'DISCONNECTED',  'JOIN_CHANNEL', 'CHANNEL_JOINED', 'LEAVE_CHANNEL', 'CHANNEL_LEAVED' and export defaultSocketStages #13
- Allow to pass one stage as a string for `createCustomRoutine` #14
- Fix typo in readme #12
